### PR TITLE
adding start script that works on linux and mac, and hopefully windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/jermbo/SampleAPIs#readme",
   "main": "index.js",
   "scripts": {
+    "start": "./node_modules/.bin/browser-sync start --server --directory --port 7777 --serveStatic './FuturamaDB' --files './FuturamaDB' &  ./node_modules/.bin/json-server --watch futuramadb.json --port 4000",
     "futurama-mac": "./node_modules/.bin/browser-sync start --server --directory --port 7777 --serveStatic './FuturamaDB' --files './FuturamaDB' |  ./node_modules/.bin/json-server --watch futuramadb.json --port 4000",
     "futurama-win": "./node_modules/.bin/browser-sync start --server --directory --port 7777 --serveStatic './FuturamaDB' --files './FuturamaDB' &  ./node_modules/.bin/json-server --watch futuramadb.json --port 4000"
   },


### PR DESCRIPTION
Fixing the function to use the traditional

npm start