### PR TITLE
Corrected the health graphql home page link

### DIFF
--- a/src/apiList.js
+++ b/src/apiList.js
@@ -133,7 +133,7 @@ module.exports = [
       "Sometimes health data is hard to come by. This endpoints make it easy for you to test your apps with examples of health data such as medical professions.",
     desc: "An API with health and medical information",
     link: "health",
-    graphLink: "health",
+    graphLink: "health/graphql",
     endPoints: ["professions"]
   },
   {


### PR DESCRIPTION
Quick fix noticed that the graphLink for health was pointed to the API Link.
Also did a quick check to see if any of the others were incorrect, did not find any.