### PR TITLE
Add initial tests for apiList.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   ],
   "scripts": {
     "start": "node ./src/sampleapis.js",
-    "dev": "nodemon ./src/sampleapis.js"
+    "dev": "nodemon ./src/sampleapis.js",
+    "test": "jest"
   },
   "engines": {
     "node": "12.x"
@@ -30,6 +31,7 @@
     "pug": "^3.0.0"
   },
   "devDependencies": {
+    "jest": "^26.5.3",
     "nodemon": "^2.0.4"
   }
 }

--- a/src/tests/apis.test.js
+++ b/src/tests/apis.test.js
@@ -1,0 +1,53 @@
+const fs = require("fs");
+const path = require("path");
+const apiList = require('../apiList.js');
+
+describe('List of APIs (apiList.js)', () => {
+
+    it('is not empty', () => {
+        expect(apiList.length).toBeGreaterThan(0);
+    })
+
+    it('contains APIs with valid ids', () => {
+        expect(apiList.filter( api => api.id > 0 )).toHaveLength(apiList.length);
+    })
+
+    it('contains APIs with valid links', () => {
+        expect(apiList.filter( api => api.link && api.link.length > 0 )).toHaveLength(apiList.length);
+    })
+
+    it('contains APIs with valid graphql links', () => {
+        expect(apiList.filter( api => api.graphLink === `${api.link}/graphql`)).toHaveLength(apiList.length);
+    })
+
+    it('contains APIs with valid titles', () => {
+        expect(apiList.filter( api => api.title && api.title.length > 0 )).toHaveLength(apiList.length);
+    })
+
+    it('contains APIs with valid descriptions', () => {
+        expect(apiList.filter( api => api.desc && api.desc.length > 0 )).toHaveLength(apiList.length);
+    })
+
+    it('contains APIs with valid long descriptions', () => {
+        expect(apiList.filter( api => api.longDesc && api.longDesc.length > 0 )).toHaveLength(apiList.length);
+    })
+
+    it('contains APIs with at least one endpoint', () => {
+        expect(apiList.filter( api => api.endPoints && Array.isArray(api.endPoints) && api.endPoints.length > 0 )).toHaveLength(apiList.length);
+    })
+
+    it('have valid .json files associated', () => {
+        expect(apiList.filter( api => {
+            let rawData = fs.readFileSync(path.join(__dirname, `../api/${api.link}.json`));
+            return rawData && rawData.length > 0;
+        })).toHaveLength(apiList.length);
+    })
+
+    it('have valid backup .json files associated', () => {
+        expect(apiList.filter( api => {
+            let rawData = fs.readFileSync(path.join(__dirname, `../api/${api.link}.json.backup`));
+            return rawData && rawData.length > 0;
+        })).toHaveLength(apiList.length);
+    })
+
+});


### PR DESCRIPTION
Initial implementation of #91 

Added tests using Jest for the following:

✅ Ensure all .json files in the api folder have id's associated with each entry point.
✅ Ensure all .json files in the api folder have at least 1 endpoint.
❌ Ensure all endpoints are included in the apiList.js file
✅ Ensure all endpoints included have the minimum values.
✅ Ensure all .json files in the api folder have associated backup file. .json.backup
❌ Ensure all endpoints are rendering.
❌ Ensure CRUD works on each endpoints.
✅ apiList.js entry should have the following information:
> {
>     id: 0, // Unique ID
>     title: "", // Title to be displayed on home and individual pages
>     longDesc: "", // A long description meant for display on the individual page. 
>     desc: "", // A short description meant for display on the home page
>     link: "", // Link to be used in the url. This should match the json file name exactly.
>     graphLink: "", // The same name as the link, but with a '/graphql' in at the end.  
>     endPoints: [ "" , ... ], // list of available endpoints, in string format. 
> }

To test just run `npm install` and `npm run test`. Tests are located in the `/src/tests` folder but can be relocated wherever needed.