### PR TITLE
Making the list of endpoints have the titles clickable

### DIFF
--- a/client/src/components/APICard/APICard.tsx
+++ b/client/src/components/APICard/APICard.tsx
@@ -16,8 +16,8 @@ const APICard: React.FC<Props> = ({ api, featured = false }) => {
       <div className="api-card__inner">
         <APICategories categories={api.metaData.categories} />
         <header className="api-card__header">
-          <h2 className="api-card__title">{api.metaData.title}</h2>
-          <Link className="btn" to={`api-list/${api.link}`}>
+          <Link className="btn noleftmargin" to={`api-list/${api.link}`}>
+            <h2 className="api-card__title">{api.metaData.title}</h2>&nbsp;
             <FontAwesomeIcon icon={faLink} />
           </Link>
           {featured && (

--- a/client/src/pages/APIDetails/APIDetails.tsx
+++ b/client/src/pages/APIDetails/APIDetails.tsx
@@ -47,7 +47,7 @@ const APIDetails: React.FC<Props> = () => {
         <h2 className="page-header__title">{singleAPI.metaData.title}</h2>
         <APICategories categories={singleAPI.metaData.categories} />
         <p className="page-header__desc">{singleAPI.metaData.longDesc}</p>
-        <p>Endpoint: <a href={thisApiEndpoint} target="_blank" style={{ color: "white", textDecoration: "underline"  }}>{thisApiEndpoint}</a>&nbsp;<FontAwesomeIcon icon={faLink} /></p>
+        <p>Endpoint: <a href={thisApiEndpoint} target="_blank"  rel="noreferrer" style={{ color: "white", textDecoration: "underline"  }}>{thisApiEndpoint}</a>&nbsp;<FontAwesomeIcon icon={faLink} /></p>
       </header>
       <div className="section">
         <div className="section-header">

--- a/client/src/styles/_api-card.scss
+++ b/client/src/styles/_api-card.scss
@@ -86,6 +86,11 @@
       outline: 2px solid var(--card-color);
     }
   }
+  
+  .noleftmargin {
+    margin-left: 0;
+    padding-left: 0;
+  }
 }
 
 .api-card__desc {


### PR DESCRIPTION
These changes allow you to click on the name of the endpoint (say beer) not just the link on the right oh the title to make it easy for others to click on.