### PR TITLE
#130 Update Oregon State Flag

### DIFF
--- a/server/api/the-states.json
+++ b/server/api/the-states.json
@@ -377,7 +377,7 @@
       "largest_city": "Portland",
       "admitted_to_union": "February 14, 1859",
       "population": "4,217,737",
-      "flag": "https://en.wikipedia.org/wiki/Oregon#/media/File:Flag_of_Oregon.svg"
+      "flag": "https://upload.wikimedia.org/wikipedia/commons/b/b9/Flag_of_Oregon.svg"
     },
     {
       "id": 38,

--- a/server/api/the-states.json.backup
+++ b/server/api/the-states.json.backup
@@ -377,7 +377,7 @@
       "largest_city": "Portland",
       "admitted_to_union": "February 14, 1859",
       "population": "4,217,737",
-      "flag": "https://en.wikipedia.org/wiki/Oregon#/media/File:Flag_of_Oregon.svg"
+      "flag": "https://upload.wikimedia.org/wikipedia/commons/b/b9/Flag_of_Oregon.svg"
     },
     {
       "id": 38,


### PR DESCRIPTION
Fixes #130

This PR addresses the issue of the current Oregon State flag URL being invalid as an image source.
The new URL is valid and points to the correct Oregon state flag on Wikipedia.
This image renders correctly when used as an image source.
It also aligns with the other state flag URLs.
PR/Issue Guidelines have been followed.