### PR TITLE
143 dynamic api list

### DIFF
--- a/client/src/context/GlobalContext.tsx
+++ b/client/src/context/GlobalContext.tsx
@@ -40,12 +40,12 @@ const GlobalProvider: React.FC = ({ children }) => {
 
   useEffect(() => {
     if (APIState === AppStateEnum.ready) {
-      const list = data?.data?.APIList || ([] as APIData[]);
+      const list = data?.data?.APIListData || ([] as APIData[]);
       setAPIList(list);
       generateCategories(list);
       return;
     }
-  }, [APIState, data?.data?.APIList]);
+  }, [APIState, data?.data?.APIListData]);
 
   const values = {
     navVisible,

--- a/client/src/utils/Interfaces.ts
+++ b/client/src/utils/Interfaces.ts
@@ -21,7 +21,7 @@ export interface FetchState<T> {
 }
 
 export interface APIListResponse {
-  APIList: APIData[];
+  APIListData: APIData[];
 }
 
 export interface APIData {
@@ -37,13 +37,13 @@ export interface MetaData {
   desc: string;
   featured: boolean;
   categories: string[];
-  examples: Example[];
+  examples?: Example[];
 }
 
 export interface Example {
   hash: string;
-  user: string;
-  defaultTab: string;
   title: string;
   endpoint: string;
+  user?: string;
+  defaultTab?: string;
 }

--- a/server/routes/base-apis.js
+++ b/server/routes/base-apis.js
@@ -1,29 +1,34 @@
 const express = require("express");
+const router = express.Router();
 const path = require("path");
 const jsonServer = require("json-server");
 const jsonGraphqlExpress = require("json-graphql-server");
+
+const { getAPIListData } = require("../utils/getAPIListData");
 
 const { apiLimits } = require("../utils/rateLimiterDefaults");
 const { getFromFile } = require("../utils/utils");
 
 const { verifyData } = require("../utils/verifyData");
 
-const ApiList = require("../apiList");
+const init = async () => {
+  const APIListData = await getAPIListData();
 
-const router = express.Router();
+  APIListData.forEach(({ link }) => {
+    const dataPath = path.join(__dirname, `../api/${link}.json`);
+    const data = getFromFile(dataPath);
 
-// API EndPoint Route
-ApiList.forEach(({ link }) => {
-  const dataPath = path.join(__dirname, `../api/${link}.json`);
-  const data = getFromFile(dataPath);
-  try {
-    router.use(`/${link}/graphql`, apiLimits, jsonGraphqlExpress.default(data));
-  } catch (err) {
-    console.log(`Unable to set up /${link}/graphql`);
-    console.error(err);
-  }
+    try {
+      router.use(`/${link}/graphql`, apiLimits, jsonGraphqlExpress.default(data));
+    } catch (err) {
+      console.log(`Unable to set up /${link}/graphql`);
+      console.error(err);
+    }
 
-  router.use(`/${link}`, verifyData, apiLimits, jsonServer.router(dataPath));
-});
+    router.use(`/${link}`, verifyData, apiLimits, jsonServer.router(dataPath));
+  });
+};
+
+init();
 
 module.exports = router;

--- a/server/routes/frontend.js
+++ b/server/routes/frontend.js
@@ -1,28 +1,26 @@
 const express = require("express");
-const fs = require("fs");
-const path = require("path");
-
 const router = express.Router();
 
-let APIList = [];
-const directoryPath = path.join(__dirname, "../api");
+const { getAPIListData } = require("../utils/getAPIListData");
+
+let APIListData = [];
 
 router.get("/", async (req, res) => {
-  if (!APIList.length) {
-    await getApiList();
+  if (!APIListData.length) {
+    APIListData = await getAPIListData();
   }
 
   res.json({
     status: 200,
     data: {
-      APIList,
+      APIListData,
     },
   });
 });
 
 router.get("/:name", async (req, res) => {
-  if (!APIList.length) {
-    await getApiList();
+  if (!APIListData.length) {
+    APIListData = await getAPIListData();
   }
 
   res.json({
@@ -30,26 +28,5 @@ router.get("/:name", async (req, res) => {
     id: req.params.name,
   });
 });
-
-const getApiList = async () => {
-  let files = await fs.readdirSync(directoryPath);
-  files = files.filter((f) => !f.includes(".backup"));
-  APIList = files.map((file) => {
-    if (file.includes(".backup")) {
-      return false;
-    }
-    const data = JSON.parse(fs.readFileSync(path.join(__dirname, `../api/${file}`)));
-    const endpoints = Object.keys(data);
-    const metaData = data.metaData[0];
-    const name = file.split(".")[0].toLowerCase();
-
-    return {
-      name,
-      link: name,
-      metaData,
-      endpoints: endpoints.filter((e) => e != "metaData"),
-    };
-  });
-};
 
 module.exports = router;

--- a/server/routes/reset.js
+++ b/server/routes/reset.js
@@ -2,11 +2,18 @@ const express = require("express");
 const path = require("path");
 const fs = require("fs");
 const router = express.Router();
-const ApiList = require("../apiList");
+
+const { getAPIListData } = require("../utils/getAPIListData");
+
+let APIListData = [];
 
 // Reset API Route
-router.get("/all", (req, res) => {
-  ApiList.forEach((page) => {
+router.get("/all", async (req, res) => {
+  if (!APIListData.length) {
+    APIListData = await getAPIListData();
+  }
+
+  APIListData.forEach((page) => {
     const api = page.link;
 
     const backupFile = path.join(__dirname, `../api/${api}.json.backup`);
@@ -26,9 +33,13 @@ router.get("/all", (req, res) => {
 });
 
 // Main EndPoint Route
-router.get("/:id", (req, res) => {
+router.get("/:id", async (req, res) => {
+  if (!APIListData.length) {
+    APIListData = await getAPIListData();
+  }
+
   const id = req.params.id.toLowerCase();
-  const data = ApiList.filter((api) => id == api.link.toLowerCase())[0];
+  const data = APIListData.filter((api) => id == api.link.toLowerCase())[0];
   const api = data.link;
 
   const backupFile = path.join(__dirname, `../api/${api}.json.backup`);

--- a/server/sampleapis.js
+++ b/server/sampleapis.js
@@ -2,9 +2,6 @@ const express = require("express");
 const bodyParser = require("body-parser");
 const path = require("path");
 const cors = require("cors");
-const ApiList = require("./apiList");
-// const morgan = require('morgan');
-// const corsOptions = require("./cors");
 
 // Express App
 const app = express();
@@ -38,6 +35,10 @@ app.use("/frontend", frontend);
 
 const create = require("./routes/create-apis");
 
+//! Deprecation Notice
+//* This is to serve the old static design site.
+//* The `apiList.js` will be removed in future versions.
+const ApiList = require("./apiList");
 app.get("/", (req, res) => {
   res.render("index", {
     apiList: JSON.stringify(ApiList),

--- a/server/utils/getAPIListData.js
+++ b/server/utils/getAPIListData.js
@@ -1,0 +1,26 @@
+const fs = require("fs");
+const path = require("path");
+
+const directoryPath = path.join(__dirname, "../api");
+
+const getAPIListData = async () => {
+  let files = await fs.readdirSync(directoryPath);
+  files = files.filter((f) => !f.includes(".backup"));
+  return files.map((file) => {
+    const data = JSON.parse(fs.readFileSync(path.join(__dirname, `../api/${file}`)));
+    const endpoints = Object.keys(data);
+    const metaData = data.metaData[0];
+    const name = file.split(".")[0].toLowerCase();
+
+    return {
+      name,
+      link: name,
+      metaData,
+      endpoints: endpoints.filter((e) => e != "metaData"),
+    };
+  });
+};
+
+module.exports = {
+  getAPIListData,
+};


### PR DESCRIPTION
`APIList` was originally intended to populate the static version of the site. This was problematic for a few reasons, but mainly there is a chance it does not reflect the actual state of the JSONs that power the API. This is due to its hand crafted nature. 

In a previous upgrade, I created a way to dynamically read the JSON files and get the information needed to power the site. I thought I made this change throughout the back end, only to give a demo and realize that is not the case. 

This PR address that issue. The API List is now fully dynamic and we are no longer required to manually update a static JavaScript file to accomplish the front end population.

Closes #143 